### PR TITLE
Update Popup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ getSession().then(async (session) => {
 
 #### Login with a PopUp Window
 
-By default, the user is redirected to the login page within the same window, but you might want to maintain the state of your application without it being interrupted by a redirect. To do so, you can use a popup. If you do want to use a popup, you should provide a `popUpRedirectPath` for the popup window to redirect to. At this path you should run the `handlePopUpRedirect` function
+By default, the user is redirected to the login page within the same window, but you might want to maintain the state of your application without it being interrupted by a redirect. To do so, you can use a popup. 
+
+The issuer's login page is opened in a popup, which then redirects the user to `popUpRedirectPath`. Running `handleRedirect` at this path stores the `accessToken` and `webId` in localStorage. The main window waits for the popup to close before creating the session from the stored credentials.
 
 `index.html`:
 ```html
@@ -172,7 +174,7 @@ By default, the user is redirected to the login page within the same window, but
 <head>
 <script src="/path/to/solidAuthFetcher.bundle.js"></script>
 <script>
-  solidAuthFetcher.handlePopUpRedirect()
+  solidAuthFetcher.handleRedirect().then(()=>window.close());
 </script>
 <head>
 </html>


### PR DESCRIPTION
The README currently describes the use of `handlePopUpRedirect`, which doesn't exist.
The text has been updated to describe the use of `handleRedirect`, and to briefly describe how this works.

In case it's useful, here's the relevant implementation:
https://github.com/solid/solid-auth-fetcher/blob/877dd07e8a0ecd00121414b21d1aeffbb72660d0/src/login/popUp/PopUpLoginHandler.ts#L62-L79
