### PR TITLE
Remove node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/jest": "^24.0.24",
-    "@types/node-fetch": "^2.5.6",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "concurrently": "^5.2.0",
@@ -55,7 +54,7 @@
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^25.1.0",
-    "node-fetch": "^2.6.0",
+    "cross-fetch": "^4.0.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.5.1",
     "ts-loader": "^7.0.4",

--- a/src/obtainAuthHeaders.ts
+++ b/src/obtainAuthHeaders.ts
@@ -22,7 +22,7 @@
  */
 
 import { customAuthFetcher } from "./index";
-// import fetch from "node-fetch";
+import fetch from "cross-fetch";
 import AuthFetcher from "./AuthFetcher";
 import Debug from "debug";
 

--- a/src/obtainAuthHeaders.ts
+++ b/src/obtainAuthHeaders.ts
@@ -22,7 +22,7 @@
  */
 
 import { customAuthFetcher } from "./index";
-import fetch from "node-fetch";
+// import fetch from "node-fetch";
 import AuthFetcher from "./AuthFetcher";
 import Debug from "debug";
 


### PR DESCRIPTION
Node-fetch is stale, causes problems in downstream libraries, and is now replaceable with  the better and more recently updated cross-fetch.  I wasn't able to build solid-auth-fetcher, but substituting cross-fetch for node-fetch directy in the obtainAuthHeaders.js eliminated the downstream errors (in solid-node-client and solid-shell). 