### PR TITLE
Revert "Remove node-fetch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/jest": "^24.0.24",
+    "@types/node-fetch": "^2.5.6",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "concurrently": "^5.2.0",
@@ -54,7 +55,7 @@
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^25.1.0",
-    "cross-fetch": "^4.0.0",
+    "node-fetch": "^2.6.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.5.1",
     "ts-loader": "^7.0.4",

--- a/src/obtainAuthHeaders.ts
+++ b/src/obtainAuthHeaders.ts
@@ -22,7 +22,7 @@
  */
 
 import { customAuthFetcher } from "./index";
-import fetch from "cross-fetch";
+import fetch from "node-fetch";
 import AuthFetcher from "./AuthFetcher";
 import Debug from "debug";
 


### PR DESCRIPTION
Reverts solid-contrib/solid-auth-fetcher#35

This PR seems to break `npm test` - maybe all occurrences of `node-fetch` in the tests folder should just be changed to `cross-fetch`?